### PR TITLE
Optional topics argument for ExactMessageHandler 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,10 +35,10 @@ This takes the classname of the handler class to use, if you have not changed an
 
 This is used to configure which topics to change, it should have the following format: sourcetopic1,targettopic1;sourcetopic2,targettopic2;...
 
-It is a semicolon separated list of string pairs, which are itself separated by a comma. In the above example any message from the topic *sourcetopic1* would be mirrored to *targettopic1* (and the same with *2*) on the target cluster. Any other topics that MirrorMaker is following will not be changed and written to a topic of the same name on the target cluster.
+It is a semicolon separated list of string pairs, which are itself separated by a comma. In the bellow example any message from the topic *test_source* would be mirrored to *test_target* (and the same with *2*) on the target cluster. Any other topics that MirrorMaker is following will not be changed and written to a topic of the same name on the target cluster.
 
 ``` bash
-kafka-mirror-maker --consumer.config consumer.properties --producer.config producer.properties --whitelist test_.* --message.handler com.opencore.RenameTopicHandler --message.handler.args `test_source,test_target;test_source2,test_target2`
+kafka-mirror-maker --consumer.config consumer.properties --producer.config producer.properties --whitelist test_.* --message.handler com.opencore.RenameTopicHandler --message.handler.args 'test_source,test_target;test_source2,test_target2'
 ```
 
 
@@ -49,5 +49,19 @@ Instead the partititon number from the original message is taken and used on the
 
 This will create Exceptions, if the target topic has a different partition count than the source topic, as MirrorMaker will either try to write to non-existing partitions (target < source) or leave partitions empty (target > source).
 
-This message handler takes no configuration.
+This message handler takes these optional args:
 
+**--message.handler.args**: 
+
+This is used to configure topics to be exactly copied. Suppose you need to mirror multiple topics but only some of them have 
+the same partition count in source and target.
+
+It is a comma separated list of strings. In the bellow example any message from the topic *test_exact* would be mirrored with the same partitioning number in messages (and the same with *2*) on the target cluster. Any other topics that MirrorMaker is following will not be changed and written to a topic bypassing source messages partitioning.
+
+If the parameter is an explicit empty list all topics will be mirrored bypassing source message partitioning.
+
+If the parameter is not provided at all than all topics will be copied with the same partitioning number in messages.
+
+``` bash
+kafka-mirror-maker --consumer.config consumer.properties --producer.config producer.properties --whitelist test_.* --message.handler com.opencore.ExactMessageHandler --message.handler.args 'test_exact,test_exact2'
+```

--- a/Readme.md
+++ b/Readme.md
@@ -56,11 +56,11 @@ This message handler takes these optional args:
 This is used to configure topics to be exactly copied. Suppose you need to mirror multiple topics but only some of them have 
 the same partition count in source and target.
 
-It is a comma separated list of strings. In the bellow example any message from the topic *test_exact* would be mirrored with the same partitioning number in messages (and the same with *2*) on the target cluster. Any other topics that MirrorMaker is following will not be changed and written to a topic bypassing source messages partitioning.
+It is a comma separated list of strings. In the bellow example any message from the topic *test_exact* would be mirrored with the same partitioning number in messages (and the same with *2*) on the target cluster. Any other topics (for example *test_exact_3*) that MirrorMaker is following will not be changed and written to a topic bypassing source messages partitioning.
 
 If the parameter is an explicit empty list all topics will be mirrored bypassing source message partitioning.
 
-If the parameter is not provided at all than all topics will be copied with the same partitioning number in messages.
+If the parameter is not provided all topics will be copied with the same partitioning number in messages.
 
 ``` bash
 kafka-mirror-maker --consumer.config consumer.properties --producer.config producer.properties --whitelist test_.* --message.handler com.opencore.ExactMessageHandler --message.handler.args 'test_exact,test_exact2'

--- a/src/main/java/com/opencore/ExactMessageHandler.java
+++ b/src/main/java/com/opencore/ExactMessageHandler.java
@@ -1,9 +1,12 @@
 package com.opencore;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import kafka.consumer.BaseConsumerRecord;
 import kafka.tools.MirrorMaker;
+import kafka.tools.MirrorMaker.defaultMirrorMakerMessageHandler$;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.RecordBatch;
 
@@ -17,8 +20,38 @@ import org.apache.kafka.common.record.RecordBatch;
  * be written to non-existent partitions which will fail.
  */
 public class ExactMessageHandler implements MirrorMaker.MirrorMakerMessageHandler {
+  private Collection<String> topics;
+
+  /**
+   * Constructor that will be called when no args are passed on the command line
+   */
+  public ExactMessageHandler() {
+
+  }
+
+  /**
+   * Constructor that will be passed the args passed on the command line.
+   *
+   * @param topicsArg CSV of topics for which messages will be exactly recreated with this handler.
+   */
+  public ExactMessageHandler(String topicsArg) {
+    this.topics = new HashSet<>();
+
+    String[] topicsArgArray = topicsArg.split(",");
+    for (String topicArg: topicsArgArray ) {
+      topics.add(topicArg);
+    }
+  }
+
   public List<ProducerRecord<byte[], byte[]>> handle(BaseConsumerRecord record) {
-    Long timestamp = record.timestamp() == RecordBatch.NO_TIMESTAMP ? null : record.timestamp();
-    return Collections.singletonList(new ProducerRecord<byte[], byte[]>(record.topic(), record.partition(), timestamp, record.key(), record.value(), record.headers()));
+    if (topics == null || topics.contains(record.topic())) {
+
+      Long timestamp = record.timestamp() == RecordBatch.NO_TIMESTAMP ? null : record.timestamp();
+      return Collections.singletonList(
+          new ProducerRecord<byte[], byte[]>(record.topic(), record.partition(), timestamp, record.key(), record.value(),
+              record.headers()));
+    } else {
+      return defaultMirrorMakerMessageHandler$.MODULE$.handle(record);
+    }
   }
 }


### PR DESCRIPTION
This PR adds an argument for ExactMessageHandler to filter topics to be exactly copied.

Suppose some of the whitelisted topics have mismatching partitioning in source / target and you need to run only one instance of kafka-mirror-maker.

The argument is optional, to allow backwards compatibility when not specified - ExactMessageHandler will consider all topics to be copied with partitioning number in messages the same as in source.